### PR TITLE
feat: add Car structure and player assignment functionality

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,7 +1,7 @@
 mod systems {
     // mod actions;
     // mod mercenary;
-  
+
 }
 
 mod contracts {
@@ -25,7 +25,8 @@ mod models {
     // mod mission;
     // mod npc;
     mod rare_item_mg;
-    mod rare_item_inventory ;
+    mod rare_item_inventory;
+    mod car;
 }
 
 
@@ -33,5 +34,5 @@ mod tests {
     //mod test_world;
     // mod test_inflict_damage;
     //  mod test_rare_item ;
-   
+
 }

--- a/src/models/car.cairo
+++ b/src/models/car.cairo
@@ -1,0 +1,113 @@
+use core::fmt::{Display, Formatter, Error};
+
+#[derive(Drop, Serde)]
+#[dojo::model]
+pub struct Car {
+    #[key]
+    id: felt252,
+    model: ByteArray,
+    speed: felt252,
+    player_id: Option<felt252>,
+}
+
+#[generate_trait]
+impl CarImpl of CarTrait {
+    fn create_car(id: felt252, model: ByteArray, speed: felt252) -> Car {
+        Car { id, model, speed, player_id: Option::None }
+    }
+
+    fn assign_car_to_player(ref self: Car, player_id: felt252) {
+        assert!(self.player_id.is_none(), "The car is already assigned to a player");
+
+        self.player_id = Option::Some(player_id);
+    }
+}
+
+impl CarDisplay of Display<Car> {
+    fn fmt(self: @Car, ref f: Formatter) -> Result<(), Error> {
+        let id = *self.id;
+        let model = self.model;
+        let speed = *self.speed;
+        let mut player_id = 0;
+
+        if let Option::Some(player_id_stored) = *self.player_id {
+            player_id = player_id_stored;
+        }
+
+        write!(f, "=== Car Details ===\n")?;
+        write!(f, "ID: {}\n", id)?;
+        write!(f, "Model: {}\n", model)?;
+        write!(f, "Speed: {}\n", speed)?;
+        write!(f, "Player ID: {}\n", player_id)?;
+        write!(f, "=================\n")?;
+        Result::Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::{Display, Formatter, Error};
+    use super::{Car, CarTrait};
+
+    #[test]
+    fn test_create_car() {
+        let id = 1;
+        let model = "Ferrari";
+        let speed = 200;
+
+        let car = CarTrait::create_car(id, model.clone(), speed);
+
+        assert!(car.id == id, "Car ID is not correct");
+        assert!(car.model == model, "Car model is not correct");
+        assert!(car.speed == speed, "Car speed is not correct");
+    }
+
+    #[test]
+    fn test_assign_car_to_player() {
+        let mut car = Car { id: 1, model: "Ferrari", speed: 200, player_id: Option::None };
+
+        let player_id = 1;
+        car.assign_car_to_player(player_id);
+
+        assert!(car.player_id == Option::Some(player_id), "Player ID is not correct");
+    }
+
+    #[test]
+    #[should_panic(expected: ("The car is already assigned to a player",))]
+    fn test_unsuccessful_assign_car_to_multiple_players() {
+        let mut car = Car { id: 1, model: "Ferrari", speed: 200, player_id: Option::None };
+
+        let first_player_id = 1;
+        car.assign_car_to_player(first_player_id);
+
+        assert!(
+            car.player_id == Option::Some(first_player_id),
+            "Player ID after first assignment is incorrect",
+        );
+
+        let second_player_id = 2;
+        car.assign_car_to_player(second_player_id);
+    }
+
+    #[test]
+    fn test_car_display_details() {
+        let mut car = Car { id: 1, model: "Ferrari", speed: 200, player_id: Option::None };
+
+        let player_id = 1;
+        car.assign_car_to_player(player_id);
+
+        let details = format!("{}", car);
+
+        let expected_details = "=== Car Details ===\n"
+            + "ID: 1\n"
+            + "Model: Ferrari\n"
+            + "Speed: 200\n"
+            + "Player ID: 1\n"
+            + "=================\n";
+
+        println!("Generated Details:\n{}", details);
+        println!("Expected Details:\n{}", expected_details);
+
+        assert_eq!(details, expected_details, "Car details do not match the expected output");
+    }
+}


### PR DESCRIPTION
### 📝 Implement Car structure that can be assigned to a player and tests  

#### 🛠️ Issue  
Closes #11 

#### 📖 Description  
This Pull Request introduces a structure for cars, allowing cars to be created and assigned to players while maintaining data integrity. The implementation includes the car model, assignment logic, and comprehensive tests to ensure robustness.  

### Key Features  

**Car Model:**  
- **Attributes:**  
  - `id` (type `felt252`): Unique identifier for the car.  
  - `model` (type `ByteArray`): Represents the car's model name.  
  - `speed` (type `felt252`): Indicates the car's speed.  
  - `player_id` (type `Option<felt252>`): Stores the player ID to whom the car is assigned (nullable).  

**Functions:**  
- **`create_car:`**  
  - Initializes a car instance with its attributes, setting the `player_id` to `None` by default.  
- **`assign_car_to_player:`**  
  - Assigns the car to a player.  
  - Ensures the car is not already assigned to another player.  
  - Prevents overwriting an existing assignment without explicit unassignment.  
- **`fmt:`**  
  - Implements the `Display` trait to provide a detailed, formatted description of the car, including its attributes and the assigned player.  

### 🧪 Tests  

1. **`test_create_car:`**  
   - Validates that the `create_car` function initializes cars with the correct attributes.  

2. **`test_assign_car_to_player:`**  
   - Ensures a car can be assigned to a player and the association is correctly stored.  

3. **`test_unsuccessful_assign_car_to_multiple_players:`**  
   - Verifies that assigning a car already associated with another player raises an error.  

4. **`test_car_display_details:`**  
   - Tests the output of the `fmt` method to ensure the generated car details match the expected output format.  

### 🖼️ Screenshots
![image](https://github.com/user-attachments/assets/34f2ac93-217f-4b8f-a1e2-47ef177758fd)
